### PR TITLE
Change default symbol visibility to hidden, only expose pg_query_ symbols

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ endif
 SRC_FILES := $(wildcard src/*.c src/postgres/*.c) vendor/protobuf-c/protobuf-c.c vendor/xxhash/xxhash.c protobuf/pg_query.pb-c.c
 OBJ_FILES := $(SRC_FILES:.c=.o)
 
-override CFLAGS += -g -I. -I./vendor -I./src/include -I./src/postgres/include -Wall -Wno-unused-function -Wno-unused-value -Wno-unused-variable -fno-strict-aliasing -fwrapv -fPIC
+override CFLAGS += -g -I. -I./vendor -I./src/include -I./src/postgres/include -Wall -Wno-unused-function -Wno-unused-value -Wno-unused-variable -fno-strict-aliasing -fwrapv -fPIC -fvisibility=hidden
 
 ifeq ($(OS),Windows_NT)
 override CFLAGS += -I./src/postgres/include/port/win32

--- a/pg_query.h
+++ b/pg_query.h
@@ -4,6 +4,10 @@
 #include <stdint.h>
 #include <sys/types.h>
 
+#ifndef PUBLIC
+#define PUBLIC __attribute__((visibility("default")))
+#endif
+
 typedef struct {
 	char* message; // exception message
 	char* funcname; // source function of exception (e.g. SearchSysCache)
@@ -95,17 +99,17 @@ typedef enum
 extern "C" {
 #endif
 
-PgQueryNormalizeResult pg_query_normalize(const char* input);
-PgQueryNormalizeResult pg_query_normalize_utility(const char* input);
-PgQueryScanResult pg_query_scan(const char* input);
-PgQueryParseResult pg_query_parse(const char* input);
-PgQueryParseResult pg_query_parse_opts(const char* input, int parser_options);
-PgQueryProtobufParseResult pg_query_parse_protobuf(const char* input);
-PgQueryProtobufParseResult pg_query_parse_protobuf_opts(const char* input, int parser_options);
-PgQueryPlpgsqlParseResult pg_query_parse_plpgsql(const char* input);
+PgQueryNormalizeResult PUBLIC pg_query_normalize(const char* input);
+PgQueryNormalizeResult PUBLIC pg_query_normalize_utility(const char* input);
+PgQueryScanResult PUBLIC pg_query_scan(const char* input);
+PgQueryParseResult PUBLIC pg_query_parse(const char* input);
+PgQueryParseResult PUBLIC pg_query_parse_opts(const char* input, int parser_options);
+PgQueryProtobufParseResult PUBLIC pg_query_parse_protobuf(const char* input);
+PgQueryProtobufParseResult PUBLIC pg_query_parse_protobuf_opts(const char* input, int parser_options);
+PgQueryPlpgsqlParseResult PUBLIC pg_query_parse_plpgsql(const char* input);
 
-PgQueryFingerprintResult pg_query_fingerprint(const char* input);
-PgQueryFingerprintResult pg_query_fingerprint_opts(const char* input, int parser_options);
+PgQueryFingerprintResult PUBLIC pg_query_fingerprint(const char* input);
+PgQueryFingerprintResult PUBLIC pg_query_fingerprint_opts(const char* input, int parser_options);
 
 // Use pg_query_split_with_scanner when you need to split statements that may
 // contain parse errors, otherwise pg_query_split_with_parser is recommended
@@ -114,22 +118,22 @@ PgQueryFingerprintResult pg_query_fingerprint_opts(const char* input, int parser
 // Note that we try to support special cases like comments, strings containing
 // ";" on both, as well as oddities like "CREATE RULE .. (SELECT 1; SELECT 2);"
 // which is treated as as single statement.
-PgQuerySplitResult pg_query_split_with_scanner(const char *input);
-PgQuerySplitResult pg_query_split_with_parser(const char *input);
+PgQuerySplitResult PUBLIC pg_query_split_with_scanner(const char *input);
+PgQuerySplitResult PUBLIC pg_query_split_with_parser(const char *input);
 
-PgQueryDeparseResult pg_query_deparse_protobuf(PgQueryProtobuf parse_tree);
+PgQueryDeparseResult PUBLIC pg_query_deparse_protobuf(PgQueryProtobuf parse_tree);
 
-void pg_query_free_normalize_result(PgQueryNormalizeResult result);
-void pg_query_free_scan_result(PgQueryScanResult result);
-void pg_query_free_parse_result(PgQueryParseResult result);
-void pg_query_free_split_result(PgQuerySplitResult result);
-void pg_query_free_deparse_result(PgQueryDeparseResult result);
-void pg_query_free_protobuf_parse_result(PgQueryProtobufParseResult result);
-void pg_query_free_plpgsql_parse_result(PgQueryPlpgsqlParseResult result);
-void pg_query_free_fingerprint_result(PgQueryFingerprintResult result);
+void PUBLIC pg_query_free_normalize_result(PgQueryNormalizeResult result);
+void PUBLIC pg_query_free_scan_result(PgQueryScanResult result);
+void PUBLIC pg_query_free_parse_result(PgQueryParseResult result);
+void PUBLIC pg_query_free_split_result(PgQuerySplitResult result);
+void PUBLIC pg_query_free_deparse_result(PgQueryDeparseResult result);
+void PUBLIC pg_query_free_protobuf_parse_result(PgQueryProtobufParseResult result);
+void PUBLIC pg_query_free_plpgsql_parse_result(PgQueryPlpgsqlParseResult result);
+void PUBLIC pg_query_free_fingerprint_result(PgQueryFingerprintResult result);
 
 // Optional, cleans up the top-level memory context (automatically done for threads that exit)
-void pg_query_exit(void);
+void PUBLIC pg_query_exit(void);
 
 // Postgres version information
 #define PG_MAJORVERSION "16"

--- a/src/pg_query_internal.h
+++ b/src/pg_query_internal.h
@@ -8,17 +8,21 @@
 #define STDERR_BUFFER_LEN 4096
 #define DEBUG
 
+#ifndef PUBLIC
+#define PUBLIC __attribute__((visibility("default")))
+#endif
+
 typedef struct {
   List *tree;
   char* stderr_buffer;
   PgQueryError* error;
 } PgQueryInternalParsetreeAndError;
 
-PgQueryInternalParsetreeAndError pg_query_raw_parse(const char* input, int parser_options);
+PgQueryInternalParsetreeAndError PUBLIC pg_query_raw_parse(const char* input, int parser_options);
 
-void pg_query_free_error(PgQueryError *error);
+void PUBLIC pg_query_free_error(PgQueryError *error);
 
-MemoryContext pg_query_enter_memory_context();
-void pg_query_exit_memory_context(MemoryContext ctx);
+MemoryContext PUBLIC pg_query_enter_memory_context();
+void PUBLIC pg_query_exit_memory_context(MemoryContext ctx);
 
 #endif

--- a/src/pg_query_parse.c
+++ b/src/pg_query_parse.c
@@ -169,7 +169,7 @@ PgQueryProtobufParseResult pg_query_parse_protobuf_opts(const char* input, int p
 	return result;
 }
 
-void pg_query_free_parse_result(PgQueryParseResult result)
+void PUBLIC pg_query_free_parse_result(PgQueryParseResult result)
 {
 	if (result.error) {
 		pg_query_free_error(result.error);


### PR DESCRIPTION
Symbols were conflicting with libpq, so hid them from linker.